### PR TITLE
Add Complete TODO List to README from all .py files

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,3 +382,428 @@ If you find our model, data, or evaluation code useful, please kindly cite our p
 }
 ```
 
+
+
+---
+
+### 📝 Complete TODO List
+- `ExGRPO/exgrpo/verl/examples/split_placement/split_monkey_patch.py:141` - make a canonical logger that supports various backend
+- `ExGRPO/exgrpo/verl/tests/e2e/check_results.py:21` - this function needs error handling
+- `ExGRPO/exgrpo/verl/tests/model/test_transformer.py:22` - (sgm): add more models for test
+- `ExGRPO/exgrpo/verl/tests/model/test_transformer.py:50` - (sgm): we can construct the position_ids_rmpad here
+- `ExGRPO/exgrpo/verl/tests/model/test_transformer.py:111` - (sgm): we can construct the position_ids_rmpad here
+- `ExGRPO/exgrpo/verl/tests/model/test_transformers_ulysses.py:34` - (sgm): add more models for test
+- `ExGRPO/exgrpo/verl/tests/model/test_transformers_ulysses.py:81` - (sgm): we can construct the position_ids_rmpad here
+- `ExGRPO/exgrpo/verl/tests/model/test_transformers_ulysses.py:159` - (sgm): we can construct the position_ids_rmpad here
+- `ExGRPO/exgrpo/verl/tests/ray/test_high_level_scheduling_api.py:25` - pass *args and **kwargs is bug prone and not very convincing
+- `ExGRPO/exgrpo/verl/tests/ray/test_worker_group_basics.py:43` - pass *args and **kwargs is bug prone and not very convincing
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_fsdp_worker.py:54` - (sgm): support FSDP hybrid shard for larger model
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_fsdp_worker.py:83` - it seems that manual offload is slowly than FSDP offload
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_fsdp_worker.py:123` - (zhangchi.usc1992): 1. support create from random initialized model. 2. Support init with FSDP directly
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_fsdp_worker.py:163` - (zhangchi.usc1992) remove this after we switch to fsdp2
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_fsdp_worker.py:199` - (zhangchi.usc1992, shengguangming) fix me. Current, auto_wrap_policy causes HFRollout to hang in Gemma
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_fsdp_worker.py:207` - add transformer policy
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_fsdp_worker.py:226` - add more optimizer args into config
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_fsdp_worker.py:252` - (sgm): support FSDP hybrid shard for larger model
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_fsdp_worker.py:263` - a sharding manager that do nothing?
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_fsdp_worker.py:426` - here, we should return all metrics
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_fsdp_worker.py:586` - support DCP and save sharded checkpoints
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_trainer.py:90` - add other ways to estimate advantages
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_trainer.py:150` - support each role have individual ray_worker_group_cls,
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_trainer.py:197` - we have to make sure the batch size is divisible by the dp size
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_trainer.py:508` - make a canonical logger that supports various backend
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_trainer.py:552` - add response length
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_trainer_acc_rebatch.py:63` - we have to make sure the batch size is divisible by the dp size
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_trainer_acc_rebatch.py:437` - make a canonical logger that supports various backend
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_trainer_acc_rebatch.py:592` - check path
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_trainer_acc_rebatch.py:628` - from remote not implemented yet
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_trainer_experience.py:64` - support each role have individual ray_worker_group_cls,
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_trainer_experience.py:534` - make a canonical logger that supports various backend
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_trainer_helper.py:40` - add other ways to estimate advantages
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_trainer_helper.py:97` - add response length
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_vllm_rollout.py:43`
+- `ExGRPO/exgrpo/verl/verl/mix_src/mix_vllm_rollout_exp.py:43`
+- `ExGRPO/exgrpo/verl/verl/models/llama/megatron/layers/parallel_attention.py:380` - llama does not have dropout in the config??
+- `ExGRPO/exgrpo/verl/verl/models/llama/megatron/layers/parallel_decoder.py:78` - add sequence parallel operator reduce_scatter here
+- `ExGRPO/exgrpo/verl/verl/models/llama/megatron/layers/parallel_decoder.py:86` - add sequence parallel operator all_gather here
+- `ExGRPO/exgrpo/verl/verl/models/llama/megatron/layers/parallel_decoder.py:90` - add sequence parallel operator reduce_scatter here
+- `ExGRPO/exgrpo/verl/verl/models/llama/megatron/modeling_llama_megatron.py:330` - for better performance, the sp padding should be removed at each layer. Not sure the performance gap
+- `ExGRPO/exgrpo/verl/verl/models/llama/megatron/modeling_llama_megatron.py:588` - for better performance, the sp padding should be removed at each layer. Not sure the performance gap
+- `ExGRPO/exgrpo/verl/verl/models/registry.py:21` - (sgm): HF may supported more than listed here, we should add more after testing
+- `ExGRPO/exgrpo/verl/verl/models/transformers/llama.py:88` - These transpose are quite inefficient but Flash Attention requires the layout [batch_size, sequence_length, num_heads, head_dim]. We would need to refactor the KV cache
+- `ExGRPO/exgrpo/verl/verl/protocol.py:164` - (zhangchi.usc1992) add consistency check
+- `ExGRPO/exgrpo/verl/verl/protocol.py:260` - we can actually lift this restriction if needed
+- `ExGRPO/exgrpo/verl/verl/protocol.py:346` - (zhangchi.usc1992) whether to copy
+- `ExGRPO/exgrpo/verl/verl/single_controller/ray/base.py:439` - create a class with customizable name
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/arg_utils.py:64` - (shengguangming): delete the unused args
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/arg_utils.py:147` - (woosuk): Support fine-grained seeds (e.g., seed per request).
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/llm.py:237` - (shengguangming): maybe we can hack the autoregressive logics without only apply post process for better performance
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/llm.py:241` - (sgm): we can optimize it by making the dataloader yield List[int] without padding.
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/llm.py:257` - (shengguangming): can be optimzied by rewrite the Sampler._get_logprobs() logits
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/llm_engine_sp.py:99` - (woosuk): Print more configs in debug mode.
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/llm_engine_sp.py:101` - currently is hfconfig
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/llm_engine_sp.py:112` - (shengguangming): maybe we can choose init here or from arguments
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/llm_engine_sp.py:145` - check get_lora_tokenizer func
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/llm_engine_sp.py:586` - check this input
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/llm_engine_sp.py:661` - we may not need to decode
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/model_loader.py:67` - (shengguangming): latest commit in vllm fix awq for this function and add load_weights
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/model_loader.py:96` - (pad to be divided by 4)
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/model_loader.py:224` - (zhuohan): Change the get_logits part to a separate stage.
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/tokenizer.py:56` - (sgm): the lora tokenizer is also passed, but may be different
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/weight_loaders.py:62` - check megatron
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/weight_loaders.py:84` - need to implement a general way to deal with prefix
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/worker.py:109` - do not use cupy
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/worker.py:209` - (woosuk): Profile swapping overhead and optimize if needed.
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_3_1/worker.py:291` - (shengguangming): maybe we should also flag the megatron is initialized
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/arg_utils.py:44`
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/arg_utils.py:109` - (shengguangming): delete the unused args
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/arg_utils.py:192` - (woosuk): Support fine-grained seeds (e.g., seed per request).
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/arg_utils.py:257` - spec config
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/config.py:136` - for multimodal model
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/hf_weight_loader.py:81`
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/llm.py:268` - (shengguangming): maybe we can hack the autoregressive logics without only apply post process for better performance
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/llm.py:272` - (sgm): we can optimize it by making the dataloader yield List[int] without padding.
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/llm.py:288` - (shengguangming): can be optimzied by rewrite the Sampler._get_logprobs() logits
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/llm_engine_sp.py:128` - (woosuk): Print more configs in debug mode.
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/llm_engine_sp.py:130` - currently is hfconfig
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/llm_engine_sp.py:143` - (shengguangming): maybe we can choose init here or from arguments
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/llm_engine_sp.py:145` - check tokenizer class
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/llm_engine_sp.py:153` - don't know what's the usage
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/llm_engine_sp.py:228` - (sgm): add for verl but we may not tokenizer in Rollout
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/llm_engine_sp.py:237` - check whether we should rebuild the CUDAGraph every iter when offload/load KVCache
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/megatron_weight_loaders.py:67` - check megatron
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/megatron_weight_loaders.py:254` - need to implement a general way to deal with prefix
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/megatron_weight_loaders.py:272` - (shengguangming): latest commit in vllm fix awq for this function and add load_weights
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/megatron_weight_loaders.py:325` - (pad to be divided by 4)
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/megatron_weight_loaders.py:337` - remove dependencies from megatron
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/model_loader.py:141` - (sgm): This is a hack, we need to register the load_weight() func for each model in vllm
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/model_loader.py:226` - (sgm): This is a hack, we need to register the load_weight() func for each model in vllm
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/model_runner.py:274` - (sgm): perform sampling on rank 0
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/parallel_state.py:236` - this will hang
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/parallel_state.py:245` - will hang when used with device mesh
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/parallel_state.py:247` - init using device mesh
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/spmd_gpu_executor.py:62` - (sgm): verl not support speculative decode now
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/spmd_gpu_executor.py:208` - (sgm): not implemented async executor yet
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/tokenizer.py:61` - (sgm): the lora tokenizer is also passed, but may be different
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/worker.py:30` - (sgm): check why vllm has similar file in vllm.model_executor.parallel_utils.parallel_state
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_4_2/worker.py:270` - (sgm): check whether need this
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/arg_utils.py:53` - (sgm): check this
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/arg_utils.py:54` - (sgm): check this
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/arg_utils.py:143` - (shengguangming): delete the unused args
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/arg_utils.py:226` - (woosuk): Support fine-grained seeds (e.g., seed per request).
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/arg_utils.py:366` - spec config
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/config.py:191` - check whether this is necessary
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/hf_weight_loader.py:32`
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/llm.py:148` - check usagecontext
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/llm.py:205` - (sgm): we can optimize it by making the dataloader yield List[int] without padding.
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/llm.py:221` - (shengguangming): can be optimzied by rewrite the Sampler._get_logprobs() logits
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/llm_engine_sp.py:143` - (woosuk): Print more configs in debug mode.
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/llm_engine_sp.py:160` - (shengguangming): maybe we can choose init here or from arguments
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/llm_engine_sp.py:262` - (sgm): add for verl but we may not tokenizer in Rollout
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/llm_engine_sp.py:271` - check whether we should rebuild the CUDAGraph every iter when offload/load KVCache
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/megatron_weight_loaders.py:67` - check megatron
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/megatron_weight_loaders.py:254` - need to implement a general way to deal with prefix
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/megatron_weight_loaders.py:272` - (shengguangming): latest commit in vllm fix awq for this function and add load_weights
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/model_loader.py:152` - (sgm): This is a hack, we need to register the load_weight() func for each model in vllm
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/model_loader.py:239` - (sgm): This is a hack, we need to register the load_weight() func for each model in vllm
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/parallel_state.py:94` - (sgm): deviate from the v0.5.4, not pp now
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/parallel_state.py:138` - check why True is not work in Ray trainer
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/parallel_state.py:165` - check why True is not work in Ray trainer
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/parallel_state.py:177` - init using device mesh (not support hybrid engine now)
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/parallel_state.py:249` - check why True is not work in Ray trainer
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/parallel_state.py:253` - init using device mesh (not support hybrid engine now)
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/spmd_gpu_executor.py:65` - (sgm): verl not support speculative decode now
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/spmd_gpu_executor.py:243` - (sgm): not implemented async executor yet
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/tokenizer.py:61` - (sgm): the lora tokenizer is also passed, but may be different
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/worker.py:29` - (sgm): check why vllm has similar file in vllm.model_executor.parallel_utils.parallel_state
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/worker.py:84` - we don't need driver
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/worker.py:103` - (sgm): set correct model runner class
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_5_4/worker.py:301` - (sgm): check whether need this
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/hf_weight_loader.py:29`
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/llm.py:147` - check usagecontext
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/llm.py:170` - (sgm): we can optimize it by making the dataloader yield List[int] without padding.
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/llm.py:186` - (shengguangming): can be optimzied by rewrite the Sampler._get_logprobs() logits
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/llm_engine_sp.py:174` - (woosuk): Print more configs in debug mode.
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/llm_engine_sp.py:336` - (sgm): add for verl but we may not tokenizer in Rollout
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/llm_engine_sp.py:345` - check whether we should rebuild the CUDAGraph every iter when offload/load KVCache
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/megatron_weight_loaders.py:68` - check megatron
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/megatron_weight_loaders.py:255` - need to implement a general way to deal with prefix
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/megatron_weight_loaders.py:273` - (shengguangming): latest commit in vllm fix awq for this function and add load_weights
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/model_loader.py:170` - (sgm): This is a hack, we need to register the load_weight() func for each model in vllm
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/model_loader.py:273` - (sgm): This is a hack, we need to register the load_weight() func for each model in vllm
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/parallel_state.py:97` - (sgm): deviate from the v0.5.4, not pp now
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/parallel_state.py:144` - check why True is not work in Ray trainer
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/parallel_state.py:172` - check why True is not work in Ray trainer
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/parallel_state.py:185` - init using device mesh (not support hybrid engine now)
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/parallel_state.py:257` - check why True is not work in Ray trainer
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/parallel_state.py:262` - init using device mesh (not support hybrid engine now)
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/spmd_gpu_executor.py:73` - (sgm): verl not support speculative decode now
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/spmd_gpu_executor.py:246` - (sgm): not implemented async executor yet
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/worker.py:33` - (sgm): check why vllm has similar file in vllm.model_executor.parallel_utils.parallel_state
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/worker.py:92` - we don't need driver
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/worker.py:110` - (sgm): set correct model runner class
+- `ExGRPO/exgrpo/verl/verl/third_party/vllm/vllm_v_0_6_3/worker.py:311` - (sgm): check whether need this
+- `ExGRPO/exgrpo/verl/verl/trainer/fsdp_sft_trainer.py:77` - add checkpoint manager
+- `ExGRPO/exgrpo/verl/verl/trainer/fsdp_sft_trainer.py:140` - (zhangchi.usc1992):
+- `ExGRPO/exgrpo/verl/verl/trainer/fsdp_sft_trainer.py:316` - add a unified tracking
+- `ExGRPO/exgrpo/verl/verl/trainer/fsdp_sft_trainer.py:333` - (zhangchi.usc1992) add back checkpoint manager. Currently, it blocks when uploading to hdfs. So very slow.
+- `ExGRPO/exgrpo/verl/verl/trainer/ppo/ray_trainer.py:129` - add other ways to estimate advantages
+- `ExGRPO/exgrpo/verl/verl/trainer/ppo/ray_trainer.py:207` - add response length
+- `ExGRPO/exgrpo/verl/verl/trainer/ppo/ray_trainer.py:330` - support each role have individual ray_worker_group_cls,
+- `ExGRPO/exgrpo/verl/verl/trainer/ppo/ray_trainer.py:379` - we have to make sure the batch size is divisible by the dp size
+- `ExGRPO/exgrpo/verl/verl/trainer/ppo/ray_trainer.py:632` - check path
+- `ExGRPO/exgrpo/verl/verl/trainer/ppo/ray_trainer.py:667` - from remote not implemented yet
+- `ExGRPO/exgrpo/verl/verl/trainer/ppo/ray_trainer.py:885` - make a canonical logger that supports various backend
+- `ExGRPO/exgrpo/verl/verl/utils/checkpoint/fsdp_checkpoint_manager.py:101` - shall we remove previous ckpt every save?
+- `ExGRPO/exgrpo/verl/verl/utils/checkpoint/fsdp_checkpoint_manager.py:135` - address optimizer is None
+- `ExGRPO/exgrpo/verl/verl/utils/hdfs_io.py:67` - (haibin.lin):
+- `ExGRPO/exgrpo/verl/verl/utils/hdfs_io.py:102` - (haibin.lin):
+- `ExGRPO/exgrpo/verl/verl/utils/megatron_utils.py:202` - (sgm): check how to disable megatron timers
+- `ExGRPO/exgrpo/verl/verl/utils/model.py:164` - we can make this faster
+- `ExGRPO/exgrpo/verl/verl/utils/model.py:272` - to find a better way to load mistral7b-rm lm_head
+- `ExGRPO/exgrpo/verl/verl/utils/torch_functional.py:375` - add them back
+- `ExGRPO/exgrpo/verl/verl/workers/actor/megatron_actor.py:158` - (zhangchi.usc1992): actually, this function should only return log_prob and this logic should be handled by user outside
+- `ExGRPO/exgrpo/verl/verl/workers/actor/megatron_actor.py:225` - actually, we just need to control the sampling order.
+- `ExGRPO/exgrpo/verl/verl/workers/actor/megatron_actor.py:301` - we may use the new schedule instead
+- `ExGRPO/exgrpo/verl/verl/workers/critic/megatron_critic.py:176` - we may use the new schedule instead
+- `ExGRPO/exgrpo/verl/verl/workers/fsdp_workers.py:88` - (sgm): support FSDP hybrid shard for larger model
+- `ExGRPO/exgrpo/verl/verl/workers/fsdp_workers.py:117` - it seems that manual offload is slowly than FSDP offload
+- `ExGRPO/exgrpo/verl/verl/workers/fsdp_workers.py:157` - (zhangchi.usc1992): 1. support create from random initialized model. 2. Support init with FSDP directly
+- `ExGRPO/exgrpo/verl/verl/workers/fsdp_workers.py:197` - (zhangchi.usc1992) remove this after we switch to fsdp2
+- `ExGRPO/exgrpo/verl/verl/workers/fsdp_workers.py:225` - (zhangchi.usc1992, shengguangming) fix me. Current, auto_wrap_policy causes HFRollout to hang in Gemma
+- `ExGRPO/exgrpo/verl/verl/workers/fsdp_workers.py:233` - add transformer policy
+- `ExGRPO/exgrpo/verl/verl/workers/fsdp_workers.py:252` - add more optimizer args into config
+- `ExGRPO/exgrpo/verl/verl/workers/fsdp_workers.py:278` - (sgm): support FSDP hybrid shard for larger model
+- `ExGRPO/exgrpo/verl/verl/workers/fsdp_workers.py:289` - a sharding manager that do nothing?
+- `ExGRPO/exgrpo/verl/verl/workers/fsdp_workers.py:416` - here, we should return all metrics
+- `ExGRPO/exgrpo/verl/verl/workers/fsdp_workers.py:811` - (sgm): we may need to extract it to dp_reward_model.py
+- `ExGRPO/exgrpo/verl/verl/workers/megatron_workers.py:106` - (sgm): Currently, we only support reference model param offload
+- `ExGRPO/exgrpo/verl/verl/workers/megatron_workers.py:204` - add more optimizer args into config
+- `ExGRPO/exgrpo/verl/verl/workers/megatron_workers.py:338` - here, we should return all metrics
+- `ExGRPO/exgrpo/verl/verl/workers/megatron_workers.py:444` - (sgm): support critic model offload
+- `ExGRPO/exgrpo/verl/verl/workers/megatron_workers.py:478` - support vpp here
+- `ExGRPO/exgrpo/verl/verl/workers/megatron_workers.py:507` - add more optimizer args into config
+- `ExGRPO/exgrpo/verl/verl/workers/megatron_workers.py:667` - add more optimizer args into config
+- `ExGRPO/exgrpo/verl/verl/workers/megatron_workers.py:720` - reward model use itself tokenizer instead of sft tokenizer
+- `ExGRPO/exgrpo/verl/verl/workers/reward_model/megatron/reward_model.py:145` - (sgm): check why is bfloat16
+- `ExGRPO/exgrpo/verl/verl/workers/reward_model/megatron/reward_model.py:192` - actually, we just need to control the sampling order.
+- `ExGRPO/exgrpo/verl/verl/workers/reward_model/megatron/reward_model.py:233` - we may use the new schedule instead
+- `ExGRPO/exgrpo/verl/verl/workers/rollout/hf_rollout.py:98` - filter out the seq with no answers like ds-chat
+- `ExGRPO/exgrpo/verl/verl/workers/rollout/vllm_rollout/vllm_rollout.py:43`
+- `ExGRPO/exgrpo/verl/verl/workers/sharding_manager/fsdp_ulysses.py:49` - check how to set seed for each model
+- `ExGRPO/exgrpo/verl/verl/workers/sharding_manager/fsdp_ulysses.py:56` - check how to set seed for each model
+- `ExGRPO/exgrpo/verl/verl/workers/sharding_manager/fsdp_vllm.py:82` - offload FSDP model weights
+- `ExGRPO/exgrpo/verl/verl/workers/sharding_manager/fsdp_vllm.py:113` - Current impl doesn't consider FSDP with torch micro-dp
+- `ExGRPO/exgrpo/verl/verl/workers/sharding_manager/fsdp_vllm.py:122` - Current impl doesn't consider FSDP with torch micro-dp
+- `ExGRPO/exgrpo/verl/verl/workers/sharding_manager/fsdp_vllm.py:130` - shall we build a micro_dp group for vllm when integrating with vLLM?
+- `ExGRPO/exgrpo/verl/verl/workers/sharding_manager/megatron_vllm.py:76` - after binding to the memory buffer, we can load the checkpoint here
+- `ExGRPO/exgrpo/verl/verl/workers/sharding_manager/megatron_vllm.py:253` - (sgm): this may not be true for FSDP -> vLLM
+- `ExGRPO/exgrpo/verl/verl/workers/sharding_manager/megatron_vllm.py:323` - (zhangchi.usc1992) We can consider copy non-tp weight to another infer buffer.
+- `luffy/test.py:1590` - add smaller page sizes when https://github.com/Dao-AILab/flash-attention/pull/824 is merged
+- `luffy/verl/examples/split_placement/split_monkey_patch.py:141` - make a canonical logger that supports various backend
+- `luffy/verl/tests/e2e/check_results.py:21` - this function needs error handling
+- `luffy/verl/tests/model/test_transformer.py:22` - (sgm): add more models for test
+- `luffy/verl/tests/model/test_transformer.py:50` - (sgm): we can construct the position_ids_rmpad here
+- `luffy/verl/tests/model/test_transformer.py:111` - (sgm): we can construct the position_ids_rmpad here
+- `luffy/verl/tests/model/test_transformers_ulysses.py:34` - (sgm): add more models for test
+- `luffy/verl/tests/model/test_transformers_ulysses.py:81` - (sgm): we can construct the position_ids_rmpad here
+- `luffy/verl/tests/model/test_transformers_ulysses.py:159` - (sgm): we can construct the position_ids_rmpad here
+- `luffy/verl/tests/ray/test_high_level_scheduling_api.py:25` - pass *args and **kwargs is bug prone and not very convincing
+- `luffy/verl/tests/ray/test_worker_group_basics.py:43` - pass *args and **kwargs is bug prone and not very convincing
+- `luffy/verl/verl/mix_src/mix_fsdp_worker.py:54` - (sgm): support FSDP hybrid shard for larger model
+- `luffy/verl/verl/mix_src/mix_fsdp_worker.py:83` - it seems that manual offload is slowly than FSDP offload
+- `luffy/verl/verl/mix_src/mix_fsdp_worker.py:123` - (zhangchi.usc1992): 1. support create from random initialized model. 2. Support init with FSDP directly
+- `luffy/verl/verl/mix_src/mix_fsdp_worker.py:163` - (zhangchi.usc1992) remove this after we switch to fsdp2
+- `luffy/verl/verl/mix_src/mix_fsdp_worker.py:199` - (zhangchi.usc1992, shengguangming) fix me. Current, auto_wrap_policy causes HFRollout to hang in Gemma
+- `luffy/verl/verl/mix_src/mix_fsdp_worker.py:207` - add transformer policy
+- `luffy/verl/verl/mix_src/mix_fsdp_worker.py:226` - add more optimizer args into config
+- `luffy/verl/verl/mix_src/mix_fsdp_worker.py:252` - (sgm): support FSDP hybrid shard for larger model
+- `luffy/verl/verl/mix_src/mix_fsdp_worker.py:263` - a sharding manager that do nothing?
+- `luffy/verl/verl/mix_src/mix_fsdp_worker.py:391` - here, we should return all metrics
+- `luffy/verl/verl/mix_src/mix_fsdp_worker.py:517` - support DCP and save sharded checkpoints
+- `luffy/verl/verl/mix_src/mix_trainer.py:90` - add other ways to estimate advantages
+- `luffy/verl/verl/mix_src/mix_trainer.py:168` - support each role have individual ray_worker_group_cls,
+- `luffy/verl/verl/mix_src/mix_trainer.py:293` - we have to make sure the batch size is divisible by the dp size
+- `luffy/verl/verl/mix_src/mix_trainer.py:599` - make a canonical logger that supports various backend
+- `luffy/verl/verl/mix_src/mix_trainer.py:637` - add response length
+- `luffy/verl/verl/mix_src/mix_trainer_acc_rebatch.py:63` - we have to make sure the batch size is divisible by the dp size
+- `luffy/verl/verl/mix_src/mix_trainer_acc_rebatch.py:437` - make a canonical logger that supports various backend
+- `luffy/verl/verl/mix_src/mix_trainer_acc_rebatch.py:592` - check path
+- `luffy/verl/verl/mix_src/mix_trainer_acc_rebatch.py:628` - from remote not implemented yet
+- `luffy/verl/verl/mix_src/mix_vllm_rollout.py:43`
+- `luffy/verl/verl/models/llama/megatron/layers/parallel_attention.py:380` - llama does not have dropout in the config??
+- `luffy/verl/verl/models/llama/megatron/layers/parallel_decoder.py:78` - add sequence parallel operator reduce_scatter here
+- `luffy/verl/verl/models/llama/megatron/layers/parallel_decoder.py:86` - add sequence parallel operator all_gather here
+- `luffy/verl/verl/models/llama/megatron/layers/parallel_decoder.py:90` - add sequence parallel operator reduce_scatter here
+- `luffy/verl/verl/models/llama/megatron/modeling_llama_megatron.py:330` - for better performance, the sp padding should be removed at each layer. Not sure the performance gap
+- `luffy/verl/verl/models/llama/megatron/modeling_llama_megatron.py:588` - for better performance, the sp padding should be removed at each layer. Not sure the performance gap
+- `luffy/verl/verl/models/registry.py:21` - (sgm): HF may supported more than listed here, we should add more after testing
+- `luffy/verl/verl/models/transformers/llama.py:88` - These transpose are quite inefficient but Flash Attention requires the layout [batch_size, sequence_length, num_heads, head_dim]. We would need to refactor the KV cache
+- `luffy/verl/verl/protocol.py:164` - (zhangchi.usc1992) add consistency check
+- `luffy/verl/verl/protocol.py:260` - we can actually lift this restriction if needed
+- `luffy/verl/verl/protocol.py:346` - (zhangchi.usc1992) whether to copy
+- `luffy/verl/verl/single_controller/ray/base.py:439` - create a class with customizable name
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/arg_utils.py:64` - (shengguangming): delete the unused args
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/arg_utils.py:147` - (woosuk): Support fine-grained seeds (e.g., seed per request).
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/llm.py:237` - (shengguangming): maybe we can hack the autoregressive logics without only apply post process for better performance
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/llm.py:241` - (sgm): we can optimize it by making the dataloader yield List[int] without padding.
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/llm.py:257` - (shengguangming): can be optimzied by rewrite the Sampler._get_logprobs() logits
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/llm_engine_sp.py:99` - (woosuk): Print more configs in debug mode.
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/llm_engine_sp.py:101` - currently is hfconfig
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/llm_engine_sp.py:112` - (shengguangming): maybe we can choose init here or from arguments
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/llm_engine_sp.py:145` - check get_lora_tokenizer func
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/llm_engine_sp.py:586` - check this input
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/llm_engine_sp.py:661` - we may not need to decode
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/model_loader.py:67` - (shengguangming): latest commit in vllm fix awq for this function and add load_weights
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/model_loader.py:96` - (pad to be divided by 4)
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/model_loader.py:224` - (zhuohan): Change the get_logits part to a separate stage.
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/tokenizer.py:56` - (sgm): the lora tokenizer is also passed, but may be different
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/weight_loaders.py:62` - check megatron
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/weight_loaders.py:84` - need to implement a general way to deal with prefix
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/worker.py:109` - do not use cupy
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/worker.py:209` - (woosuk): Profile swapping overhead and optimize if needed.
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_3_1/worker.py:291` - (shengguangming): maybe we should also flag the megatron is initialized
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/arg_utils.py:44`
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/arg_utils.py:109` - (shengguangming): delete the unused args
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/arg_utils.py:192` - (woosuk): Support fine-grained seeds (e.g., seed per request).
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/arg_utils.py:257` - spec config
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/config.py:136` - for multimodal model
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/hf_weight_loader.py:81`
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/llm.py:268` - (shengguangming): maybe we can hack the autoregressive logics without only apply post process for better performance
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/llm.py:272` - (sgm): we can optimize it by making the dataloader yield List[int] without padding.
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/llm.py:288` - (shengguangming): can be optimzied by rewrite the Sampler._get_logprobs() logits
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/llm_engine_sp.py:128` - (woosuk): Print more configs in debug mode.
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/llm_engine_sp.py:130` - currently is hfconfig
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/llm_engine_sp.py:143` - (shengguangming): maybe we can choose init here or from arguments
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/llm_engine_sp.py:145` - check tokenizer class
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/llm_engine_sp.py:153` - don't know what's the usage
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/llm_engine_sp.py:228` - (sgm): add for verl but we may not tokenizer in Rollout
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/llm_engine_sp.py:237` - check whether we should rebuild the CUDAGraph every iter when offload/load KVCache
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/megatron_weight_loaders.py:67` - check megatron
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/megatron_weight_loaders.py:254` - need to implement a general way to deal with prefix
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/megatron_weight_loaders.py:272` - (shengguangming): latest commit in vllm fix awq for this function and add load_weights
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/megatron_weight_loaders.py:325` - (pad to be divided by 4)
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/megatron_weight_loaders.py:337` - remove dependencies from megatron
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/model_loader.py:141` - (sgm): This is a hack, we need to register the load_weight() func for each model in vllm
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/model_loader.py:226` - (sgm): This is a hack, we need to register the load_weight() func for each model in vllm
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/model_runner.py:274` - (sgm): perform sampling on rank 0
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/parallel_state.py:236` - this will hang
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/parallel_state.py:245` - will hang when used with device mesh
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/parallel_state.py:247` - init using device mesh
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/spmd_gpu_executor.py:62` - (sgm): verl not support speculative decode now
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/spmd_gpu_executor.py:208` - (sgm): not implemented async executor yet
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/tokenizer.py:61` - (sgm): the lora tokenizer is also passed, but may be different
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/worker.py:30` - (sgm): check why vllm has similar file in vllm.model_executor.parallel_utils.parallel_state
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_4_2/worker.py:270` - (sgm): check whether need this
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/arg_utils.py:53` - (sgm): check this
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/arg_utils.py:54` - (sgm): check this
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/arg_utils.py:143` - (shengguangming): delete the unused args
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/arg_utils.py:226` - (woosuk): Support fine-grained seeds (e.g., seed per request).
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/arg_utils.py:366` - spec config
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/config.py:191` - check whether this is necessary
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/hf_weight_loader.py:32`
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/llm.py:148` - check usagecontext
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/llm.py:205` - (sgm): we can optimize it by making the dataloader yield List[int] without padding.
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/llm.py:221` - (shengguangming): can be optimzied by rewrite the Sampler._get_logprobs() logits
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/llm_engine_sp.py:143` - (woosuk): Print more configs in debug mode.
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/llm_engine_sp.py:160` - (shengguangming): maybe we can choose init here or from arguments
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/llm_engine_sp.py:262` - (sgm): add for verl but we may not tokenizer in Rollout
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/llm_engine_sp.py:271` - check whether we should rebuild the CUDAGraph every iter when offload/load KVCache
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/megatron_weight_loaders.py:67` - check megatron
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/megatron_weight_loaders.py:254` - need to implement a general way to deal with prefix
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/megatron_weight_loaders.py:272` - (shengguangming): latest commit in vllm fix awq for this function and add load_weights
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/model_loader.py:152` - (sgm): This is a hack, we need to register the load_weight() func for each model in vllm
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/model_loader.py:239` - (sgm): This is a hack, we need to register the load_weight() func for each model in vllm
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/parallel_state.py:94` - (sgm): deviate from the v0.5.4, not pp now
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/parallel_state.py:138` - check why True is not work in Ray trainer
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/parallel_state.py:165` - check why True is not work in Ray trainer
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/parallel_state.py:177` - init using device mesh (not support hybrid engine now)
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/parallel_state.py:249` - check why True is not work in Ray trainer
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/parallel_state.py:253` - init using device mesh (not support hybrid engine now)
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/spmd_gpu_executor.py:65` - (sgm): verl not support speculative decode now
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/spmd_gpu_executor.py:243` - (sgm): not implemented async executor yet
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/tokenizer.py:61` - (sgm): the lora tokenizer is also passed, but may be different
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/worker.py:29` - (sgm): check why vllm has similar file in vllm.model_executor.parallel_utils.parallel_state
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/worker.py:84` - we don't need driver
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/worker.py:103` - (sgm): set correct model runner class
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_5_4/worker.py:301` - (sgm): check whether need this
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/hf_weight_loader.py:29`
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/llm.py:147` - check usagecontext
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/llm.py:170` - (sgm): we can optimize it by making the dataloader yield List[int] without padding.
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/llm.py:186` - (shengguangming): can be optimzied by rewrite the Sampler._get_logprobs() logits
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/llm_engine_sp.py:174` - (woosuk): Print more configs in debug mode.
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/llm_engine_sp.py:336` - (sgm): add for verl but we may not tokenizer in Rollout
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/llm_engine_sp.py:345` - check whether we should rebuild the CUDAGraph every iter when offload/load KVCache
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/megatron_weight_loaders.py:68` - check megatron
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/megatron_weight_loaders.py:255` - need to implement a general way to deal with prefix
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/megatron_weight_loaders.py:273` - (shengguangming): latest commit in vllm fix awq for this function and add load_weights
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/model_loader.py:170` - (sgm): This is a hack, we need to register the load_weight() func for each model in vllm
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/model_loader.py:273` - (sgm): This is a hack, we need to register the load_weight() func for each model in vllm
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/parallel_state.py:97` - (sgm): deviate from the v0.5.4, not pp now
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/parallel_state.py:144` - check why True is not work in Ray trainer
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/parallel_state.py:172` - check why True is not work in Ray trainer
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/parallel_state.py:185` - init using device mesh (not support hybrid engine now)
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/parallel_state.py:257` - check why True is not work in Ray trainer
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/parallel_state.py:262` - init using device mesh (not support hybrid engine now)
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/spmd_gpu_executor.py:73` - (sgm): verl not support speculative decode now
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/spmd_gpu_executor.py:246` - (sgm): not implemented async executor yet
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/worker.py:33` - (sgm): check why vllm has similar file in vllm.model_executor.parallel_utils.parallel_state
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/worker.py:92` - we don't need driver
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/worker.py:110` - (sgm): set correct model runner class
+- `luffy/verl/verl/third_party/vllm/vllm_v_0_6_3/worker.py:311` - (sgm): check whether need this
+- `luffy/verl/verl/trainer/fsdp_sft_trainer.py:77` - add checkpoint manager
+- `luffy/verl/verl/trainer/fsdp_sft_trainer.py:140` - (zhangchi.usc1992):
+- `luffy/verl/verl/trainer/fsdp_sft_trainer.py:316` - add a unified tracking
+- `luffy/verl/verl/trainer/fsdp_sft_trainer.py:333` - (zhangchi.usc1992) add back checkpoint manager. Currently, it blocks when uploading to hdfs. So very slow.
+- `luffy/verl/verl/trainer/ppo/ray_trainer.py:129` - add other ways to estimate advantages
+- `luffy/verl/verl/trainer/ppo/ray_trainer.py:207` - add response length
+- `luffy/verl/verl/trainer/ppo/ray_trainer.py:330` - support each role have individual ray_worker_group_cls,
+- `luffy/verl/verl/trainer/ppo/ray_trainer.py:379` - we have to make sure the batch size is divisible by the dp size
+- `luffy/verl/verl/trainer/ppo/ray_trainer.py:632` - check path
+- `luffy/verl/verl/trainer/ppo/ray_trainer.py:667` - from remote not implemented yet
+- `luffy/verl/verl/trainer/ppo/ray_trainer.py:880` - make a canonical logger that supports various backend
+- `luffy/verl/verl/utils/checkpoint/fsdp_checkpoint_manager.py:101` - shall we remove previous ckpt every save?
+- `luffy/verl/verl/utils/checkpoint/fsdp_checkpoint_manager.py:135` - address optimizer is None
+- `luffy/verl/verl/utils/hdfs_io.py:67` - (haibin.lin):
+- `luffy/verl/verl/utils/hdfs_io.py:102` - (haibin.lin):
+- `luffy/verl/verl/utils/megatron_utils.py:202` - (sgm): check how to disable megatron timers
+- `luffy/verl/verl/utils/model.py:164` - we can make this faster
+- `luffy/verl/verl/utils/model.py:272` - to find a better way to load mistral7b-rm lm_head
+- `luffy/verl/verl/utils/torch_functional.py:362` - add them back
+- `luffy/verl/verl/workers/actor/megatron_actor.py:158` - (zhangchi.usc1992): actually, this function should only return log_prob and this logic should be handled by user outside
+- `luffy/verl/verl/workers/actor/megatron_actor.py:225` - actually, we just need to control the sampling order.
+- `luffy/verl/verl/workers/actor/megatron_actor.py:301` - we may use the new schedule instead
+- `luffy/verl/verl/workers/critic/megatron_critic.py:176` - we may use the new schedule instead
+- `luffy/verl/verl/workers/fsdp_workers.py:88` - (sgm): support FSDP hybrid shard for larger model
+- `luffy/verl/verl/workers/fsdp_workers.py:117` - it seems that manual offload is slowly than FSDP offload
+- `luffy/verl/verl/workers/fsdp_workers.py:157` - (zhangchi.usc1992): 1. support create from random initialized model. 2. Support init with FSDP directly
+- `luffy/verl/verl/workers/fsdp_workers.py:197` - (zhangchi.usc1992) remove this after we switch to fsdp2
+- `luffy/verl/verl/workers/fsdp_workers.py:225` - (zhangchi.usc1992, shengguangming) fix me. Current, auto_wrap_policy causes HFRollout to hang in Gemma
+- `luffy/verl/verl/workers/fsdp_workers.py:233` - add transformer policy
+- `luffy/verl/verl/workers/fsdp_workers.py:252` - add more optimizer args into config
+- `luffy/verl/verl/workers/fsdp_workers.py:278` - (sgm): support FSDP hybrid shard for larger model
+- `luffy/verl/verl/workers/fsdp_workers.py:289` - a sharding manager that do nothing?
+- `luffy/verl/verl/workers/fsdp_workers.py:416` - here, we should return all metrics
+- `luffy/verl/verl/workers/fsdp_workers.py:811` - (sgm): we may need to extract it to dp_reward_model.py
+- `luffy/verl/verl/workers/megatron_workers.py:106` - (sgm): Currently, we only support reference model param offload
+- `luffy/verl/verl/workers/megatron_workers.py:204` - add more optimizer args into config
+- `luffy/verl/verl/workers/megatron_workers.py:338` - here, we should return all metrics
+- `luffy/verl/verl/workers/megatron_workers.py:444` - (sgm): support critic model offload
+- `luffy/verl/verl/workers/megatron_workers.py:478` - support vpp here
+- `luffy/verl/verl/workers/megatron_workers.py:507` - add more optimizer args into config
+- `luffy/verl/verl/workers/megatron_workers.py:667` - add more optimizer args into config
+- `luffy/verl/verl/workers/megatron_workers.py:720` - reward model use itself tokenizer instead of sft tokenizer
+- `luffy/verl/verl/workers/reward_model/megatron/reward_model.py:145` - (sgm): check why is bfloat16
+- `luffy/verl/verl/workers/reward_model/megatron/reward_model.py:192` - actually, we just need to control the sampling order.
+- `luffy/verl/verl/workers/reward_model/megatron/reward_model.py:233` - we may use the new schedule instead
+- `luffy/verl/verl/workers/rollout/hf_rollout.py:98` - filter out the seq with no answers like ds-chat
+- `luffy/verl/verl/workers/rollout/vllm_rollout/vllm_rollout.py:43`
+- `luffy/verl/verl/workers/sharding_manager/fsdp_ulysses.py:49` - check how to set seed for each model
+- `luffy/verl/verl/workers/sharding_manager/fsdp_ulysses.py:56` - check how to set seed for each model
+- `luffy/verl/verl/workers/sharding_manager/fsdp_vllm.py:82` - offload FSDP model weights
+- `luffy/verl/verl/workers/sharding_manager/fsdp_vllm.py:113` - Current impl doesn't consider FSDP with torch micro-dp
+- `luffy/verl/verl/workers/sharding_manager/fsdp_vllm.py:122` - Current impl doesn't consider FSDP with torch micro-dp
+- `luffy/verl/verl/workers/sharding_manager/fsdp_vllm.py:130` - shall we build a micro_dp group for vllm when integrating with vLLM?
+- `luffy/verl/verl/workers/sharding_manager/megatron_vllm.py:76` - after binding to the memory buffer, we can load the checkpoint here
+- `luffy/verl/verl/workers/sharding_manager/megatron_vllm.py:253` - (sgm): this may not be true for FSDP -> vLLM
+- `luffy/verl/verl/workers/sharding_manager/megatron_vllm.py:323` - (zhangchi.usc1992) We can consider copy non-tp weight to another infer buffer.


### PR DESCRIPTION
This PR adds a comprehensive `### 📝 Complete TODO List` section to the README, extracted from all `.py` files in the repository.

- **420 TODO entries** from all `.py` files across the entire repo
- Sorted lexicographically by file path, then by ascending line number within each file
- Each entry follows the format: `` `path/to/file.py:line_number` - TODO description ``
- Generated by scanning for `# TODO` markers using word-boundary matching (avoids false positives like "autodoc")
- Section title `### 📝 Complete TODO List` is preserved exactly as specified